### PR TITLE
squid:S1488 - Local Variables should not be declared and then immedia…

### DIFF
--- a/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/curator/AbstractCurdApiImpl.java
+++ b/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/curator/AbstractCurdApiImpl.java
@@ -75,8 +75,7 @@ public abstract class AbstractCurdApiImpl {
 
     protected ChildData getData(String path) {
         try {
-            ChildData childData = new ChildData(path, EMPTY_STAT, client.getData().forPath(path));
-            return childData;
+            return new ChildData(path, EMPTY_STAT, client.getData().forPath(path));
         } catch (Exception e) {
             throw new NiubiException(e);
         }

--- a/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/curator/MasterSlaveJobApiImpl.java
+++ b/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/curator/MasterSlaveJobApiImpl.java
@@ -39,8 +39,7 @@ public class MasterSlaveJobApiImpl extends AbstractCurdApiImpl implements Master
     @Override
     public List<MasterSlaveJobData> getAllJobs() {
         List<ChildData> childDataList = getChildren(getMasterSlavePathApi().getJobPath());
-        List<MasterSlaveJobData> masterSlaveJobDataList = childDataList.stream().map(MasterSlaveJobData::new).collect(Collectors.toList());
-        return masterSlaveJobDataList;
+        return childDataList.stream().map(MasterSlaveJobData::new).collect(Collectors.toList());
     }
 
     @Override

--- a/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/curator/MasterSlaveNodeApiImpl.java
+++ b/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/curator/MasterSlaveNodeApiImpl.java
@@ -42,8 +42,7 @@ public class MasterSlaveNodeApiImpl extends AbstractCurdApiImpl implements Maste
         if (ListHelper.isEmpty(childDataList)) {
             return null;
         }
-        List<MasterSlaveNodeData> masterSlaveNodeDataList = childDataList.stream().map(MasterSlaveNodeData::new).collect(Collectors.toList());
-        return masterSlaveNodeDataList;
+        return childDataList.stream().map(MasterSlaveNodeData::new).collect(Collectors.toList());
     }
 
     @Override

--- a/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/curator/StandbyJobApiImpl.java
+++ b/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/curator/StandbyJobApiImpl.java
@@ -39,8 +39,7 @@ public class StandbyJobApiImpl extends AbstractCurdApiImpl implements StandbyJob
     @Override
     public List<StandbyJobData> getAllJobs() {
         List<ChildData> childDataList = getChildren(getStandbyPathApi().getJobPath());
-        List<StandbyJobData> nodeModelList = childDataList.stream().map(StandbyJobData::new).collect(Collectors.toList());
-        return nodeModelList;
+        return childDataList.stream().map(StandbyJobData::new).collect(Collectors.toList());
     }
 
     @Override

--- a/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/curator/StandbyNodeApiImpl.java
+++ b/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/curator/StandbyNodeApiImpl.java
@@ -42,8 +42,7 @@ public class StandbyNodeApiImpl extends AbstractCurdApiImpl implements StandbyNo
         if (ListHelper.isEmpty(childDataList)) {
             return null;
         }
-        List<StandbyNodeData> standbyNodeDataList = childDataList.stream().map(StandbyNodeData::new).collect(Collectors.toList());
-        return standbyNodeDataList;
+        return childDataList.stream().map(StandbyNodeData::new).collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1488 - Local Variables should not be declared and then immediately returned or thrown

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1488

Please let me know if you have any questions.

M-Ezzat