### PR TITLE
squid:S2974 - Classes without public constructors should be final

### DIFF
--- a/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/curator/MasterSlavePathApiImpl.java
+++ b/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/curator/MasterSlavePathApiImpl.java
@@ -22,7 +22,7 @@ import com.zuoxiaolong.niubi.job.api.MasterSlavePathApi;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public class MasterSlavePathApiImpl implements MasterSlavePathApi {
+public final class MasterSlavePathApiImpl implements MasterSlavePathApi {
 
     public static final MasterSlavePathApi INSTANCE = new MasterSlavePathApiImpl();
 

--- a/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/curator/StandbyPathApiImpl.java
+++ b/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/curator/StandbyPathApiImpl.java
@@ -22,7 +22,7 @@ import com.zuoxiaolong.niubi.job.api.StandbyPathApi;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public class StandbyPathApiImpl implements StandbyPathApi {
+public final class StandbyPathApiImpl implements StandbyPathApi {
 
     public static final StandbyPathApi INSTANCE = new StandbyPathApiImpl();
 

--- a/niubi-job-cluster/src/main/java/com/zuoxiaolong/niubi/job/cluster/startup/Bootstrap.java
+++ b/niubi-job-cluster/src/main/java/com/zuoxiaolong/niubi/job/cluster/startup/Bootstrap.java
@@ -38,7 +38,7 @@ import java.util.Properties;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public class Bootstrap {
+public final class Bootstrap {
 
     private Bootstrap() {}
 

--- a/niubi-job-scanner/src/main/java/com/zuoxiaolong/niubi/job/scanner/JobScannerFactory.java
+++ b/niubi-job-scanner/src/main/java/com/zuoxiaolong/niubi/job/scanner/JobScannerFactory.java
@@ -22,7 +22,7 @@ import com.zuoxiaolong.niubi.job.core.helper.StringHelper;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public class JobScannerFactory {
+public final class JobScannerFactory {
 
     private JobScannerFactory() {}
 

--- a/niubi-job-scanner/src/main/java/com/zuoxiaolong/niubi/job/scanner/job/JobDescriptorFactory.java
+++ b/niubi-job-scanner/src/main/java/com/zuoxiaolong/niubi/job/scanner/job/JobDescriptorFactory.java
@@ -26,7 +26,7 @@ import java.lang.reflect.Method;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public class JobDescriptorFactory {
+public final class JobDescriptorFactory {
 
     private JobDescriptorFactory() {}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2974 - Classes without "public" constructors should be "final"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2974

Please let me know if you have any questions.

M-Ezzat