### PR TITLE
squid:S1610 - Abstract classes without fields should be converted to …

### DIFF
--- a/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/helper/EventHelper.java
+++ b/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/helper/EventHelper.java
@@ -22,7 +22,7 @@ import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public abstract class EventHelper {
+public interface EventHelper {
 
     public static boolean isChildAddEvent(PathChildrenCacheEvent event) {
         return event != null && event.getType() == PathChildrenCacheEvent.Type.CHILD_ADDED;

--- a/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/helper/PathHelper.java
+++ b/niubi-job-api/src/main/java/com/zuoxiaolong/niubi/job/api/helper/PathHelper.java
@@ -22,7 +22,7 @@ import com.zuoxiaolong.niubi.job.core.helper.AssertHelper;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public abstract class PathHelper {
+public interface PathHelper {
 
     public static String getParentPath(String path) {
         AssertHelper.notNull(path, "path can't be null.");

--- a/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/AssertHelper.java
+++ b/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/AssertHelper.java
@@ -22,7 +22,7 @@ package com.zuoxiaolong.niubi.job.core.helper;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public abstract class AssertHelper {
+public interface AssertHelper {
 
     /**
      * Assert that the object is not {@code null}

--- a/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/ClassHelper.java
+++ b/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/ClassHelper.java
@@ -23,7 +23,7 @@ package com.zuoxiaolong.niubi.job.core.helper;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public abstract class ClassHelper {
+public interface ClassHelper {
 
     public static String getPackageName(String className) {
         AssertHelper.notEmpty(className, "className can't be null.");

--- a/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/DateHelper.java
+++ b/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/DateHelper.java
@@ -25,7 +25,7 @@ import java.util.Date;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public abstract class DateHelper {
+public interface DateHelper {
 
     public static String format(Date date) {
         return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(date);

--- a/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/HttpHelper.java
+++ b/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/HttpHelper.java
@@ -24,7 +24,7 @@ import java.net.URL;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public abstract class HttpHelper {
+public interface HttpHelper {
 
     public static String downloadRemoteResource(String filePath, String url) throws IOException {
         HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();

--- a/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/IOHelper.java
+++ b/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/IOHelper.java
@@ -26,7 +26,7 @@ import java.net.HttpURLConnection;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public abstract class IOHelper {
+public interface IOHelper {
 
     public static void writeFile(String fileName, byte[] bytes) throws IOException {
         if (fileName != null) {

--- a/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/JarFileHelper.java
+++ b/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/JarFileHelper.java
@@ -25,7 +25,7 @@ import java.util.List;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public abstract class JarFileHelper {
+public interface JarFileHelper {
 
     public static String getJarFileName(String jarFilePath) {
         if (jarFilePath == null) {

--- a/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/ListHelper.java
+++ b/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/ListHelper.java
@@ -24,7 +24,7 @@ import java.util.List;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public abstract class ListHelper {
+public interface ListHelper {
 
     public static <T> List<T> merge(List<T> list1, List<T> list2) {
         List<T> mergeResult = new ArrayList<T>();

--- a/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/ReflectHelper.java
+++ b/niubi-job-core/src/main/java/com/zuoxiaolong/niubi/job/core/helper/ReflectHelper.java
@@ -27,7 +27,7 @@ import java.util.List;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public abstract class ReflectHelper {
+public interface ReflectHelper {
 
     public static void copyFieldValues(Object source, Object target) {
         if (source == null || target == null) {

--- a/niubi-job-scheduler/src/main/java/com/zuoxiaolong/niubi/job/scheduler/JobDataMapManager.java
+++ b/niubi-job-scheduler/src/main/java/com/zuoxiaolong/niubi/job/scheduler/JobDataMapManager.java
@@ -27,7 +27,7 @@ import org.quartz.SchedulerException;
  * @author Xiaolong Zuo
  * @since 0.9.3
  */
-public abstract class JobDataMapManager {
+public interface JobDataMapManager {
 
     public static SchedulerJobDescriptor getJobDescriptor(JobDetail jobDetail) {
         return (SchedulerJobDescriptor) jobDetail.getJobDataMap().get(SchedulerJobDescriptor.DATA_MAP_KEY);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1610 - Abstract classes without fields should be converted to interfaces

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1610

Please let me know if you have any questions.

M-Ezzat