### PR TITLE
squid:S1941, squid:S1213 - Variables should not be declared before th…

### DIFF
--- a/niubi-job-cluster/src/main/java/com/zuoxiaolong/niubi/job/cluster/startup/Bootstrap.java
+++ b/niubi-job-cluster/src/main/java/com/zuoxiaolong/niubi/job/cluster/startup/Bootstrap.java
@@ -40,8 +40,6 @@ import java.util.Properties;
  */
 public final class Bootstrap {
 
-    private Bootstrap() {}
-
     private static final ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
 
     private static final ApplicationClassLoader applicationClassLoader;
@@ -57,6 +55,8 @@ public final class Bootstrap {
     private static final Properties properties;
 
     private static Object nodeInstance;
+
+    private Bootstrap() {}
 
     public static void main(String[] args) throws Exception {
         if (!ListHelper.isEmpty(args) && "start".equals(args[0])) {

--- a/niubi-job-console/src/main/java/com/zuoxiaolong/niubi/job/console/exception/DefaultHandlerExceptionResolver.java
+++ b/niubi-job-console/src/main/java/com/zuoxiaolong/niubi/job/console/exception/DefaultHandlerExceptionResolver.java
@@ -41,12 +41,13 @@ public class DefaultHandlerExceptionResolver implements HandlerExceptionResolver
         }
         HandlerMethod handlerMethod = (HandlerMethod) handler;
         ExceptionForward methodExceptionForward = handlerMethod.getMethodAnnotation(ExceptionForward.class);
-        ExceptionForward beanExceptionForward = handlerMethod.getBeanType().getDeclaredAnnotation(ExceptionForward.class);
         StringBuffer stringBuffer = new StringBuffer("forward:");
         if (methodExceptionForward != null) {
             stringBuffer.append(methodExceptionForward.value());
             return new ModelAndView(stringBuffer.toString());
         }
+
+        ExceptionForward beanExceptionForward = handlerMethod.getBeanType().getDeclaredAnnotation(ExceptionForward.class);
         if (beanExceptionForward != null) {
             stringBuffer.append(beanExceptionForward.value());
             return new ModelAndView(stringBuffer.toString());

--- a/niubi-job-persistent/src/main/java/com/zuoxiaolong/niubi/job/persistent/hibernate/HibernateNamingStrategy.java
+++ b/niubi-job-persistent/src/main/java/com/zuoxiaolong/niubi/job/persistent/hibernate/HibernateNamingStrategy.java
@@ -41,10 +41,6 @@ public class HibernateNamingStrategy extends PhysicalNamingStrategyStandardImpl 
 		this.maxLength = maxLength;
 	}
 
-    public HibernateNamingStrategy() {
-        super();
-    }
-
     @Override
     public Identifier toPhysicalCatalogName(Identifier name, JdbcEnvironment context) {
         return addUnderscores(name);
@@ -69,6 +65,10 @@ public class HibernateNamingStrategy extends PhysicalNamingStrategyStandardImpl 
     public Identifier toPhysicalColumnName(Identifier name, JdbcEnvironment context) {
         return addUnderscores(name);
     }
+
+	public HibernateNamingStrategy() {
+		super();
+	}
 
     private Identifier addUnderscores(Identifier name) {
         if (name != null) {

--- a/niubi-job-scheduler/src/main/java/com/zuoxiaolong/niubi/job/scheduler/DefaultSchedulerManager.java
+++ b/niubi-job-scheduler/src/main/java/com/zuoxiaolong/niubi/job/scheduler/DefaultSchedulerManager.java
@@ -261,7 +261,6 @@ public class DefaultSchedulerManager implements SchedulerManager {
     public synchronized void startupManual(String group, String name, String cron, String misfirePolicy) {
         checkScheduler();
         JobKey jobKey = JobKey.jobKey(name, group);
-        ScheduleStatus scheduleStatus = jobStatusMap.get(getUniqueId(jobKey));
         SchedulerJobDescriptor jobDescriptor;
         try {
             JobDetail jobDetail = scheduler.getJobDetail(jobKey);
@@ -270,6 +269,8 @@ public class DefaultSchedulerManager implements SchedulerManager {
             LoggerHelper.error("get jobDescriptor [" + group + "," + name + "] job failed.", e);
             throw new NiubiException(e);
         }
+
+        ScheduleStatus scheduleStatus = jobStatusMap.get(getUniqueId(jobKey));
         if (scheduleStatus == ScheduleStatus.SHUTDOWN) {
             LoggerHelper.info("job [" + group + "," + name + "] now is shutdown ,begin startup.");
             try {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1941 - Variables should not be declared before they are relevant
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1941
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat