### PR TITLE
修复0.9.5.x 分支单元测试失败的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ dependency-reduced-pom.xml
 .settings/
 .project
 .classpath
+
+# exclude file
+!/niubi-job-framework/niubi-job-service/src/test/resources/niubi-job-sample-spring.jar

--- a/niubi-job-framework/niubi-job-service/src/test/java/com/zuoxiaolong/niubi/job/service/impl/AbstractSpringContextTest.java
+++ b/niubi-job-framework/niubi-job-service/src/test/java/com/zuoxiaolong/niubi/job/service/impl/AbstractSpringContextTest.java
@@ -55,11 +55,11 @@ public abstract class AbstractSpringContextTest implements ApplicationContextAwa
     }
 
     protected String getExampleJarFile() {
-        System.out.println(ClassLoader.getSystemResource("niubi-job-example-spring.jar").getFile());
-        System.out.println(AbstractSpringContextTest.class.getClassLoader().getSystemResource("niubi-job-example-spring.jar").getFile());
-        System.out.println(MasterSlaveJobLogServiceImplTest.class.getClassLoader().getSystemResource("niubi-job-example-spring.jar").getFile());
-        System.out.println(applicationContext.getClassLoader().getSystemResource("niubi-job-example-spring.jar").getFile());
-        return ClassLoader.getSystemResource("niubi-job-example-spring.jar").getFile();
+        System.out.println(ClassLoader.getSystemResource("niubi-job-sample-spring.jar").getFile());
+        System.out.println(AbstractSpringContextTest.class.getClassLoader().getSystemResource("niubi-job-sample-spring.jar").getFile());
+        System.out.println(MasterSlaveJobLogServiceImplTest.class.getClassLoader().getSystemResource("niubi-job-sample-spring.jar").getFile());
+        System.out.println(applicationContext.getClassLoader().getSystemResource("niubi-job-sample-spring.jar").getFile());
+        return ClassLoader.getSystemResource("niubi-job-sample-spring.jar").getFile();
     }
 
 }

--- a/niubi-job-framework/niubi-job-service/src/test/java/com/zuoxiaolong/niubi/job/service/impl/MasterSlaveJobLogServiceImplTest.java
+++ b/niubi-job-framework/niubi-job-service/src/test/java/com/zuoxiaolong/niubi/job/service/impl/MasterSlaveJobLogServiceImplTest.java
@@ -93,8 +93,8 @@ public class MasterSlaveJobLogServiceImplTest extends AbstractSpringContextTest{
         MasterSlaveJobSummary jobSummary = jobSummaries.get(0);
         jobSummary.setJobCron("0 * * * * ?");
         jobSummary.setMisfirePolicy("None");
-        jobSummary.setJarFileName("niubi-job-example-spring.jar");
-        jobSummary.setOriginalJarFileName("niubi-job-example-spring.jar");
+        jobSummary.setJarFileName("niubi-job-sample-spring.jar");
+        jobSummary.setOriginalJarFileName("niubi-job-sample-spring.jar");
         jobSummary.setJobOperation("Start");
         jobSummary.setContainerType("Spring");
         masterSlaveJobSummaryService.saveJobSummary(jobSummary);
@@ -105,14 +105,14 @@ public class MasterSlaveJobLogServiceImplTest extends AbstractSpringContextTest{
         masterSlaveJobLogService.updateJobLog(data);
         //判断日志是否更新成功
         MasterSlaveJobLog jobLog = baseDao.get(MasterSlaveJobLog.class, jobLogId);
-        Assert.assertEquals(jobLog.getJarFileName(), "niubi-job-example-spring.jar");
+        Assert.assertEquals(jobLog.getJarFileName(), "niubi-job-sample-spring.jar");
         Assert.assertEquals(jobLog.getJobName(), "test");
         Assert.assertEquals(jobLog.getJobOperation(), "Start");
         Assert.assertEquals(jobLog.getMisfirePolicy(), "None");
-        Assert.assertEquals(jobLog.getOriginalJarFileName(), "niubi-job-example-spring.jar");
+        Assert.assertEquals(jobLog.getOriginalJarFileName(), "niubi-job-sample-spring.jar");
         Assert.assertEquals(jobLog.getJobCron(), "0 * * * * ?");
         Assert.assertEquals(jobLog.getContainerType(), "Spring");
-        Assert.assertEquals(jobLog.getGroupName(), "com.zuoxiaolong.niubi.job.example.spring.job.Job1");
+        Assert.assertEquals(jobLog.getGroupName(), "com.zuoxiaolong.niubi.job.sample.spring.job.Job1");
     }
 
 }

--- a/niubi-job-framework/niubi-job-service/src/test/java/com/zuoxiaolong/niubi/job/service/impl/MasterSlaveJobServiceImplTest.java
+++ b/niubi-job-framework/niubi-job-service/src/test/java/com/zuoxiaolong/niubi/job/service/impl/MasterSlaveJobServiceImplTest.java
@@ -47,17 +47,17 @@ public class MasterSlaveJobServiceImplTest extends AbstractSpringContextTest{
     @Test
     public void getJob() {
         masterSlaveJobService.saveJob(getExampleJarFile(), "com.zuoxiaolong");
-        MasterSlaveJob job = masterSlaveJobService.getJob("com.zuoxiaolong.niubi.job.example.spring.job.Job1", "test", "niubi-job-example-spring.jar");
+        MasterSlaveJob job = masterSlaveJobService.getJob("com.zuoxiaolong.niubi.job.sample.spring.job.Job1", "test", "niubi-job-sample-spring.jar");
         Assert.assertNotNull(job);
     }
 
     @Test
     public void getJarFileNameList() {
         masterSlaveJobService.saveJob(getExampleJarFile(), "com.zuoxiaolong");
-        List<String> jarFileNameList = masterSlaveJobService.getJarFileNameList("com.zuoxiaolong.niubi.job.example.spring.job.Job1", "test");
+        List<String> jarFileNameList = masterSlaveJobService.getJarFileNameList("com.zuoxiaolong.niubi.job.sample.spring.job.Job1", "test");
         Assert.assertNotNull(jarFileNameList);
         Assert.assertTrue(jarFileNameList.size() == 1);
-        Assert.assertEquals("niubi-job-example-spring.jar" , jarFileNameList.get(0));
+        Assert.assertEquals("niubi-job-sample-spring.jar" , jarFileNameList.get(0));
     }
 
 }

--- a/niubi-job-framework/niubi-job-service/src/test/java/com/zuoxiaolong/niubi/job/service/impl/MasterSlaveJobSummaryServiceImplTest.java
+++ b/niubi-job-framework/niubi-job-service/src/test/java/com/zuoxiaolong/niubi/job/service/impl/MasterSlaveJobSummaryServiceImplTest.java
@@ -66,8 +66,8 @@ public class MasterSlaveJobSummaryServiceImplTest extends AbstractSpringContextT
         MasterSlaveJobSummary jobSummary = jobSummaries.get(0);
         jobSummary.setJobCron("0 * * * * ?");
         jobSummary.setMisfirePolicy("None");
-        jobSummary.setJarFileName("niubi-job-example-spring.jar");
-        jobSummary.setOriginalJarFileName("niubi-job-example-spring.jar");
+        jobSummary.setJarFileName("niubi-job-sample-spring.jar");
+        jobSummary.setOriginalJarFileName("niubi-job-sample-spring.jar");
         jobSummary.setJobOperation("Start");
         jobSummary.setContainerType("Spring");
         masterSlaveJobSummaryService.saveJobSummary(jobSummary);
@@ -84,8 +84,8 @@ public class MasterSlaveJobSummaryServiceImplTest extends AbstractSpringContextT
         String id = jobSummary.getId();
         jobSummary.setJobCron("0 * * * * ?");
         jobSummary.setMisfirePolicy("None");
-        jobSummary.setJarFileName("niubi-job-example-spring.jar");
-        jobSummary.setOriginalJarFileName("niubi-job-example-spring.jar");
+        jobSummary.setJarFileName("niubi-job-sample-spring.jar");
+        jobSummary.setOriginalJarFileName("niubi-job-sample-spring.jar");
         jobSummary.setJobOperation("Start");
         jobSummary.setContainerType("Spring");
         masterSlaveJobSummaryService.saveJobSummary(jobSummary);
@@ -106,7 +106,7 @@ public class MasterSlaveJobSummaryServiceImplTest extends AbstractSpringContextT
         masterSlaveJobService.saveJob(getExampleJarFile(), "com.zuoxiaolong");
         MasterSlaveJobSummary jobSummary = masterSlaveJobSummaryService.getAllJobSummaries().get(0);
         Assert.assertNotNull(jobSummary);
-        Assert.assertEquals(jobSummary.getGroupName(), "com.zuoxiaolong.niubi.job.example.spring.job.Job1");
+        Assert.assertEquals(jobSummary.getGroupName(), "com.zuoxiaolong.niubi.job.sample.spring.job.Job1");
         Assert.assertEquals(jobSummary.getJobName(), "test");
         MasterSlaveJobData.Data data = new MasterSlaveJobData.Data();
         data.setJobCron("0 * * * * ?");
@@ -123,7 +123,7 @@ public class MasterSlaveJobSummaryServiceImplTest extends AbstractSpringContextT
         masterSlaveJobService.saveJob(getExampleJarFile(), "com.zuoxiaolong");
         MasterSlaveJobSummary jobSummary = masterSlaveJobSummaryService.getAllJobSummaries().get(0);
         Assert.assertNotNull(jobSummary);
-        Assert.assertEquals(jobSummary.getGroupName(), "com.zuoxiaolong.niubi.job.example.spring.job.Job1");
+        Assert.assertEquals(jobSummary.getGroupName(), "com.zuoxiaolong.niubi.job.sample.spring.job.Job1");
         Assert.assertEquals(jobSummary.getJobName(), "test");
         masterSlaveJobSummaryService.saveJobSummary(jobSummary);
         MasterSlaveApiFactory apiFactory = new MasterSlaveApiFactoryImpl(client);

--- a/niubi-job-framework/niubi-job-service/src/test/java/com/zuoxiaolong/niubi/job/service/impl/StandbyJobLogServiceImplTest.java
+++ b/niubi-job-framework/niubi-job-service/src/test/java/com/zuoxiaolong/niubi/job/service/impl/StandbyJobLogServiceImplTest.java
@@ -93,8 +93,8 @@ public class StandbyJobLogServiceImplTest extends AbstractSpringContextTest{
         StandbyJobSummary jobSummary = jobSummaries.get(0);
         jobSummary.setJobCron("0 * * * * ?");
         jobSummary.setMisfirePolicy("None");
-        jobSummary.setJarFileName("niubi-job-example-spring.jar");
-        jobSummary.setOriginalJarFileName("niubi-job-example-spring.jar");
+        jobSummary.setJarFileName("niubi-job-sample-spring.jar");
+        jobSummary.setOriginalJarFileName("niubi-job-sample-spring.jar");
         jobSummary.setJobOperation("Start");
         jobSummary.setContainerType("Spring");
         standbyJobSummaryService.saveJobSummary(jobSummary);
@@ -105,14 +105,14 @@ public class StandbyJobLogServiceImplTest extends AbstractSpringContextTest{
         standbyJobLogService.updateJobLog(data);
         //判断日志是否更新成功
         StandbyJobLog jobLog = baseDao.get(StandbyJobLog.class, jobLogId);
-        Assert.assertEquals(jobLog.getJarFileName(), "niubi-job-example-spring.jar");
+        Assert.assertEquals(jobLog.getJarFileName(), "niubi-job-sample-spring.jar");
         Assert.assertEquals(jobLog.getJobName(), "test");
         Assert.assertEquals(jobLog.getJobOperation(), "Start");
         Assert.assertEquals(jobLog.getMisfirePolicy(), "None");
-        Assert.assertEquals(jobLog.getOriginalJarFileName(), "niubi-job-example-spring.jar");
+        Assert.assertEquals(jobLog.getOriginalJarFileName(), "niubi-job-sample-spring.jar");
         Assert.assertEquals(jobLog.getJobCron(), "0 * * * * ?");
         Assert.assertEquals(jobLog.getContainerType(), "Spring");
-        Assert.assertEquals(jobLog.getGroupName(), "com.zuoxiaolong.niubi.job.example.spring.job.Job1");
+        Assert.assertEquals(jobLog.getGroupName(), "com.zuoxiaolong.niubi.job.sample.spring.job.Job1");
     }
 
 }

--- a/niubi-job-framework/niubi-job-service/src/test/java/com/zuoxiaolong/niubi/job/service/impl/StandbyJobServiceImplTest.java
+++ b/niubi-job-framework/niubi-job-service/src/test/java/com/zuoxiaolong/niubi/job/service/impl/StandbyJobServiceImplTest.java
@@ -47,17 +47,17 @@ public class StandbyJobServiceImplTest extends AbstractSpringContextTest{
     @Test
     public void getJob() {
         standbyJobService.saveJob(getExampleJarFile(), "com.zuoxiaolong");
-        StandbyJob job = standbyJobService.getJob("com.zuoxiaolong.niubi.job.example.spring.job.Job1", "test", "niubi-job-example-spring.jar");
+        StandbyJob job = standbyJobService.getJob("com.zuoxiaolong.niubi.job.sample.spring.job.Job1", "test", "niubi-job-sample-spring.jar");
         Assert.assertNotNull(job);
     }
 
     @Test
     public void getJarFileNameList() {
         standbyJobService.saveJob(getExampleJarFile(), "com.zuoxiaolong");
-        List<String> jarFileNameList = standbyJobService.getJarFileNameList("com.zuoxiaolong.niubi.job.example.spring.job.Job1", "test");
+        List<String> jarFileNameList = standbyJobService.getJarFileNameList("com.zuoxiaolong.niubi.job.sample.spring.job.Job1", "test");
         Assert.assertNotNull(jarFileNameList);
         Assert.assertTrue(jarFileNameList.size() == 1);
-        Assert.assertEquals("niubi-job-example-spring.jar" , jarFileNameList.get(0));
+        Assert.assertEquals("niubi-job-sample-spring.jar" , jarFileNameList.get(0));
     }
 
 }

--- a/niubi-job-framework/niubi-job-service/src/test/java/com/zuoxiaolong/niubi/job/service/impl/StandbyJobSummaryServiceImplTest.java
+++ b/niubi-job-framework/niubi-job-service/src/test/java/com/zuoxiaolong/niubi/job/service/impl/StandbyJobSummaryServiceImplTest.java
@@ -66,8 +66,8 @@ public class StandbyJobSummaryServiceImplTest extends AbstractSpringContextTest{
         StandbyJobSummary jobSummary = jobSummaries.get(0);
         jobSummary.setJobCron("0 * * * * ?");
         jobSummary.setMisfirePolicy("None");
-        jobSummary.setJarFileName("niubi-job-example-spring.jar");
-        jobSummary.setOriginalJarFileName("niubi-job-example-spring.jar");
+        jobSummary.setJarFileName("niubi-job-sample-spring.jar");
+        jobSummary.setOriginalJarFileName("niubi-job-sample-spring.jar");
         jobSummary.setJobOperation("Start");
         jobSummary.setContainerType("Spring");
         standbyJobSummaryService.saveJobSummary(jobSummary);
@@ -84,8 +84,8 @@ public class StandbyJobSummaryServiceImplTest extends AbstractSpringContextTest{
         String id = jobSummary.getId();
         jobSummary.setJobCron("0 * * * * ?");
         jobSummary.setMisfirePolicy("None");
-        jobSummary.setJarFileName("niubi-job-example-spring.jar");
-        jobSummary.setOriginalJarFileName("niubi-job-example-spring.jar");
+        jobSummary.setJarFileName("niubi-job-sample-spring.jar");
+        jobSummary.setOriginalJarFileName("niubi-job-sample-spring.jar");
         jobSummary.setJobOperation("Start");
         jobSummary.setContainerType("Spring");
         standbyJobSummaryService.saveJobSummary(jobSummary);
@@ -106,7 +106,7 @@ public class StandbyJobSummaryServiceImplTest extends AbstractSpringContextTest{
         standbyJobService.saveJob(getExampleJarFile(), "com.zuoxiaolong");
         StandbyJobSummary jobSummary = standbyJobSummaryService.getAllJobSummaries().get(0);
         Assert.assertNotNull(jobSummary);
-        Assert.assertEquals(jobSummary.getGroupName(), "com.zuoxiaolong.niubi.job.example.spring.job.Job1");
+        Assert.assertEquals(jobSummary.getGroupName(), "com.zuoxiaolong.niubi.job.sample.spring.job.Job1");
         Assert.assertEquals(jobSummary.getJobName(), "test");
         StandbyJobData.Data data = new StandbyJobData.Data();
         data.setJobCron("0 * * * * ?");
@@ -123,7 +123,7 @@ public class StandbyJobSummaryServiceImplTest extends AbstractSpringContextTest{
         standbyJobService.saveJob(getExampleJarFile(), "com.zuoxiaolong");
         StandbyJobSummary jobSummary = standbyJobSummaryService.getAllJobSummaries().get(0);
         Assert.assertNotNull(jobSummary);
-        Assert.assertEquals(jobSummary.getGroupName(), "com.zuoxiaolong.niubi.job.example.spring.job.Job1");
+        Assert.assertEquals(jobSummary.getGroupName(), "com.zuoxiaolong.niubi.job.sample.spring.job.Job1");
         Assert.assertEquals(jobSummary.getJobName(), "test");
         standbyJobSummaryService.saveJobSummary(jobSummary);
         StandbyApiFactory apiFactory = new StandbyApiFactoryImpl(client);


### PR DESCRIPTION
### 修复问题：
#19 
### 修复方法：
1. 将跳过测试情况下打的`niubi-job-sample-spring.jar`包放在`niubi-job-framework/niubi-job-service/src/test/resources/`目录下
2. 在.gitignore中添加允许`!/niubi-job-framework/niubi-job-service/src/test/resources/niubi-job-sample-spring.jar`
3. 替换单元测试代码中的相关jar包名称和包名称